### PR TITLE
Correct voting calculation for nay votes

### DIFF
--- a/apps/frontend/src/components/promotion/PeriodVotingStatsPanel.tsx
+++ b/apps/frontend/src/components/promotion/PeriodVotingStatsPanel.tsx
@@ -29,6 +29,15 @@ export const PromotionVotingStatsPanel = ({
   contractAndConfig,
 }: PromotionVotingStatsPanelProps) => {
   const theme = useTheme();
+  const totalCastVotingPower =
+    (promotion.yea_voting_power || 0) +
+    (promotion.nay_voting_power || 0) +
+    (promotion.pass_voting_power || 0);
+
+  const getCastVotePercent = (votingPower: number) =>
+    totalCastVotingPower > 0
+      ? ((votingPower / totalCastVotingPower) * 100).toFixed(2)
+      : "0.00";
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
@@ -43,27 +52,13 @@ export const PromotionVotingStatsPanel = ({
       <Box sx={{ display: "flex", gap: 1, justifyContent: "space-between" }}>
         <Typography sx={{ color: `${theme.palette.success.main} !important` }}>
           Yea:{" "}
-          {(
-            (promotion.yea_voting_power / period.totalVotingPower) *
-            100
-          ).toFixed(0)}
-          %
+          {getCastVotePercent(promotion.yea_voting_power || 0)}%
         </Typography>
         <Typography sx={{ color: `${theme.palette.error.main} !important` }}>
-          Nay:{" "}
-          {(
-            (promotion.nay_voting_power / period.totalVotingPower) *
-            100
-          ).toFixed(0)}
-          %
+          Nay: {getCastVotePercent(promotion.nay_voting_power || 0)}%
         </Typography>
         <Typography sx={{ color: `${theme.palette.warning.main} !important` }}>
-          Pass:{" "}
-          {(
-            (promotion.pass_voting_power / period.totalVotingPower) *
-            100
-          ).toFixed(0)}
-          %
+          Pass: {getCastVotePercent(promotion.pass_voting_power || 0)}%
         </Typography>
       </Box>
     </Box>


### PR DESCRIPTION
The fix changes the vote percentage calculation from using `period.totalVotingPower` as the denominator to using only the total voting power that was actually cast:

 ```ts
   yea_voting_power + nay_voting_power + pass_voting_power
 ```

A helper, `getCastVotePercent`, now calculates each displayed percentage against that cast-vote total and safely returns "0.00" when no votes were cast.

This means the Yea/Nay/Pass percentages now represent the distribution of submitted votes, rather than each option’s share of total possible voting power. This specifically fixes Nay vote percentages appearing incorrectly low when turnout is below 100%.
